### PR TITLE
Use cgi.Serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dev:
 docker-test: test_mode=true
 docker-run: test_mode=false
 docker-run docker-test:
-	GOARCH=amd64 GOOS=linux make build && \
+	GOARCH=amd64 GOOS=linux CGO_ENABLED=0 make build && \
 	docker-compose build && \
 	TEST_MODE=$(test_mode) docker-compose up \
 	--exit-code-from cgibinftw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   dynamodb-local:
     command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"

--- a/ulticntr/assets/html.go.html
+++ b/ulticntr/assets/html.go.html
@@ -1,5 +1,3 @@
-Content-Type: text/html
-
 <!DOCTYPE html>
 
 <html>


### PR DESCRIPTION
This is a completely pointless PR but I thought I'd make it to demonstrate Go's functionality when it comes to CGI scripts. It has a pretty nifty cgi.Serve function where you can use to use a standard HTTP handler. This allows you to not worry about passing headers yourself and lets Go handle the proxying needed to make the CGI work.